### PR TITLE
Enhancement: Implement LazyListener

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     ],
     "require": {
         "php": ">=5.5",
+        "container-interop/container-interop": "^1.1",
         "league/event": "^2.1.2"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -18,5 +18,15 @@
         "fabpot/php-cs-fixer": "2.0.*@dev",
         "phpunit/phpunit": "^4.8.7",
         "refinery29/php-cs-fixer-config": "0.1.4"
+    },
+    "autoload": {
+        "psr-4": {
+            "Refinery29\\Event\\": "src"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Refinery29\\Event\\Test\\": "tests"
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
         }
     ],
     "require": {
-        "php": ">=5.5"
+        "php": ">=5.5",
+        "league/event": "^2.1.2"
     },
     "require-dev": {
         "fabpot/php-cs-fixer": "2.0.*@dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "d72297494a1e2587e35eed5dc3860686",
+    "hash": "d5021a007764433fc51fb0d61f2dd2a1",
     "packages": [
         {
             "name": "container-interop/container-interop",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,59 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "81c0900cbe1dc2a15d15153ff92d26c2",
-    "packages": [],
+    "hash": "c56cbf4ab3462295d01bf4d99c2f619b",
+    "packages": [
+        {
+            "name": "league/event",
+            "version": "2.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/event.git",
+                "reference": "e4bfc88dbcb60c8d8a2939a71f9813e141bbe4cd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/event/zipball/e4bfc88dbcb60c8d8a2939a71f9813e141bbe4cd",
+                "reference": "e4bfc88dbcb60c8d8a2939a71f9813e141bbe4cd",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "henrikbjorn/phpspec-code-coverage": "~1.0.1",
+                "phpspec/phpspec": "~2.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Event\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Frank de Jonge",
+                    "email": "info@frenky.net"
+                }
+            ],
+            "description": "Event package",
+            "keywords": [
+                "emitter",
+                "event",
+                "listener"
+            ],
+            "time": "2015-05-21 12:24:47"
+        }
+    ],
     "packages-dev": [
         {
             "name": "doctrine/instantiator",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,35 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "c56cbf4ab3462295d01bf4d99c2f619b",
+    "hash": "d72297494a1e2587e35eed5dc3860686",
     "packages": [
+        {
+            "name": "container-interop/container-interop",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/container-interop/container-interop.git",
+                "reference": "fc08354828f8fd3245f77a66b9e23a6bca48297e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/container-interop/container-interop/zipball/fc08354828f8fd3245f77a66b9e23a6bca48297e",
+                "reference": "fc08354828f8fd3245f77a66b9e23a6bca48297e",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Interop\\Container\\": "src/Interop/Container/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
+            "time": "2014-12-30 15:22:37"
+        },
         {
             "name": "league/event",
             "version": "2.1.2",

--- a/src/LazyListener.php
+++ b/src/LazyListener.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Refinery29\Event;
+
+use Interop\Container\ContainerInterface;
+use Interop\Container\Exception\ContainerException;
+use League\Event\EventInterface;
+use League\Event\ListenerInterface;
+
+class LazyListener implements ListenerInterface
+{
+    /**
+     * @var string
+     */
+    private $alias;
+
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+    /**
+     * @var ListenerInterface
+     */
+    private $listener;
+
+    /**
+     * @param string             $alias
+     * @param ContainerInterface $container
+     */
+    public function __construct($alias, ContainerInterface $container)
+    {
+        $this->container = $container;
+        $this->alias = $alias;
+    }
+
+    /**
+     * @return ListenerInterface
+     */
+    public function getListener()
+    {
+        if ($this->listener === null) {
+            try {
+                $listener = $this->container->get($this->alias);
+            } catch (ContainerException $exception) {
+                throw new \BadMethodCallException(sprintf(
+                    'Unable to fetch a service for alias "%s" from the container',
+                    $this->alias
+                ));
+            }
+
+            if (!$listener instanceof ListenerInterface) {
+                throw new \BadMethodCallException('Fetched listener does not implement ListenerInterface');
+            }
+
+            $this->listener = $listener;
+        }
+
+        return $this->listener;
+    }
+
+    public function handle(EventInterface $event)
+    {
+        $this->getListener()->handle($event);
+    }
+
+    public function isListener($listener)
+    {
+        if ($listener instanceof LazyListener) {
+            return $this === $listener;
+        }
+
+        if ($this->listener !== null) {
+            return $this->listener === $listener;
+        }
+
+        return false;
+    }
+
+    /**
+     * @param string             $alias
+     * @param ContainerInterface $container
+     *
+     * @return static
+     */
+    public static function fromAlias($alias, ContainerInterface $container)
+    {
+        return new static($alias, $container);
+    }
+}

--- a/tests/ContainerException.php
+++ b/tests/ContainerException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Refinery29\Event\Test;
+
+use Interop\Container\Exception;
+
+class ContainerException extends \Exception implements Exception\ContainerException
+{
+}

--- a/tests/LazyListenerTest.php
+++ b/tests/LazyListenerTest.php
@@ -1,0 +1,282 @@
+<?php
+
+namespace Refinery29\Test\Unit\Event;
+
+use BadMethodCallException;
+use Interop\Container\ContainerInterface;
+use League\Event\EventInterface;
+use League\Event\ListenerInterface;
+use Refinery29\Event\LazyListener;
+use Refinery29\Event\Test\ContainerException;
+use Refinery29\Event\Test\NotFoundException;
+use stdClass;
+
+class LazyListenerTest extends \PHPUnit_Framework_TestCase
+{
+    public function testImplementsInterface()
+    {
+        $alias = 'foo';
+        $container = $this->getContainerMock();
+
+        $listener = new LazyListener($alias, $container);
+
+        $this->assertInstanceOf(ListenerInterface::class, $listener);
+    }
+
+    public function testGetListenerWhenActualListenerNotManagedByContainer()
+    {
+        $this->setExpectedException(BadMethodCallException::class);
+
+        $alias = 'foo';
+
+        $container = $this->getContainerMock();
+
+        $container
+            ->expects($this->once())
+            ->method('get')
+            ->with($this->identicalTo($alias))
+            ->willThrowException(new NotFoundException('Not found'))
+        ;
+
+        $listener = new LazyListener($alias, $container);
+
+        $listener->getListener();
+    }
+
+    public function testGetListenerWhenFetchingActualListenerImpossible()
+    {
+        $this->setExpectedException(BadMethodCallException::class);
+
+        $alias = 'foo';
+
+        $container = $this->getContainerMock();
+
+        $container
+            ->expects($this->once())
+            ->method('get')
+            ->with($this->identicalTo($alias))
+            ->willThrowException(new ContainerException('Sorry!'))
+        ;
+
+        $listener = new LazyListener($alias, $container);
+
+        $listener->getListener();
+    }
+
+    public function testGetListenerWhenActualListenerDoesNotImplementListenerInterface()
+    {
+        $this->setExpectedException(BadMethodCallException::class);
+
+        $alias = 'foo';
+
+        $container = $this->getContainerMock();
+
+        $container
+            ->expects($this->once())
+            ->method('get')
+            ->with($this->identicalTo($alias))
+            ->willReturn(new stdClass())
+        ;
+
+        $listener = new LazyListener($alias, $container);
+
+        $listener->getListener();
+    }
+
+    public function testGetListenerFetchesActualListenerFromContainer()
+    {
+        $alias = 'foo';
+
+        $actualListener = $this->getListenerMock();
+
+        $container = $this->getContainerMock();
+
+        $container
+            ->expects($this->once())
+            ->method('get')
+            ->with($this->identicalTo($alias))
+            ->willReturn($actualListener)
+        ;
+
+        $listener = new LazyListener($alias, $container);
+
+        $this->assertSame($actualListener, $listener->getListener());
+    }
+
+    public function testGetListenerFetchesActualListenerOnceOnly()
+    {
+        $alias = 'foo';
+
+        $container = $this->getContainerMock();
+
+        $container
+            ->expects($this->once())
+            ->method('get')
+            ->with($this->identicalTo($alias))
+            ->willReturn($this->getListenerMock())
+        ;
+
+        $listener = new LazyListener($alias, $container);
+
+        $actualListener = $listener->getListener();
+
+        $this->assertSame($actualListener, $listener->getListener());
+    }
+
+    public function testHandleLetsActualListenerHandleEvent()
+    {
+        $event = $this->getEventMock();
+
+        $actualListener = $this->getListenerMock();
+
+        $actualListener
+            ->expects($this->once())
+            ->method('handle')
+            ->with($this->identicalTo($event))
+        ;
+
+        $alias = 'foo';
+
+        $container = $this->getContainerMock();
+
+        $container
+            ->expects($this->once())
+            ->method('get')
+            ->with($this->identicalTo($alias))
+            ->willReturn($actualListener)
+        ;
+
+        $listener = new LazyListener($alias, $container);
+
+        $listener->handle($event);
+    }
+
+    public function testIsListenerWhenComparedListenerIsSameLazyListener()
+    {
+        $alias = 'foo';
+
+        $container = $this->getContainerMock();
+
+        $container
+            ->expects($this->never())
+            ->method($this->anything())
+        ;
+
+        $listener = new LazyListener($alias, $container);
+
+        $this->assertTrue($listener->isListener($listener));
+    }
+
+    public function testIsListenerWhenComparedListenerIsDifferentLazyListener()
+    {
+        $lazyListener = $this->getLazyListenerMock();
+
+        $alias = 'foo';
+
+        $container = $this->getContainerMock();
+
+        $container
+            ->expects($this->never())
+            ->method($this->anything())
+        ;
+
+        $listener = new LazyListener($alias, $container);
+
+        $this->assertFalse($listener->isListener($lazyListener));
+    }
+
+    public function testIsListenerWhenComparedListenerIsActualListenerAndHasNotBeenFetchedFromContainer()
+    {
+        $actualListener = $this->getListenerMock();
+
+        $alias = 'foo';
+
+        $container = $this->getContainerMock();
+
+        $container
+            ->expects($this->never())
+            ->method($this->anything())
+        ;
+
+        $listener = new LazyListener($alias, $container);
+
+        $this->assertFalse($listener->isListener($actualListener));
+    }
+
+    public function testIsListenerWhenComparedListenerIsActualListenerAndHasBeenFetchedFromContainer()
+    {
+        $actualListener = $this->getListenerMock();
+
+        $alias = 'foo';
+
+        $container = $this->getContainerMock();
+
+        $container
+            ->expects($this->once())
+            ->method('get')
+            ->with($this->identicalTo($alias))
+            ->willReturn($actualListener)
+        ;
+
+        $listener = new LazyListener($alias, $container);
+
+        $listener->getListener();
+
+        $this->assertTrue($listener->isListener($listener));
+    }
+
+    public function testFromAlias()
+    {
+        $alias = 'foo';
+
+        $actualListener = $this->getListenerMock();
+
+        $container = $this->getContainerMock();
+
+        $container
+            ->expects($this->once())
+            ->method('get')
+            ->with($this->identicalTo($alias))
+            ->willReturn($actualListener)
+        ;
+
+        $listener = LazyListener::fromAlias($alias, $container);
+
+        $this->assertSame($actualListener, $listener->getListener());
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|ContainerInterface
+     */
+    private function getContainerMock()
+    {
+        return $this->getMockBuilder(ContainerInterface::class)->getMock();
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|EventInterface
+     */
+    private function getEventMock()
+    {
+        return $this->getMockBuilder(EventInterface::class)->getMock();
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|LazyListener
+     */
+    private function getLazyListenerMock()
+    {
+        return $this->getMockBuilder(LazyListener::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|ListenerInterface
+     */
+    private function getListenerMock()
+    {
+        return $this->getMockBuilder(ListenerInterface::class)->getMock();
+    }
+}

--- a/tests/NotFoundException.php
+++ b/tests/NotFoundException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Refinery29\Event\Test;
+
+use Interop\Container\Exception;
+
+class NotFoundException extends \Exception implements Exception\NotFoundException
+{
+}


### PR DESCRIPTION
This PR

* [x] requires `league/event`
* [x] requires `container-interop/container-interop`
* [x] implements a `LazyListener`, which fetches actual listeners from the composed container

Replaces https://github.com/thephpleague/event/pull/61.