### PR TITLE
Fix: Remove report script

### DIFF
--- a/bin/report-coverage
+++ b/bin/report-coverage
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-vendor/bin/test-reporter --stdout > codeclimate.json
-curl -X POST -d @codeclimate.json -H 'Content-Type: application/json' -H 'User-Agent: Code Climate (PHP Test Reporter v0.1.2)' https://codeclimate.com/test_reports --verbose


### PR DESCRIPTION
This PR

* [x] removes the Code Climate report script

Follows #8.

:information_desk_person: Turns out that the SSL issue has been fixed in `0.2.0`.