### PR TITLE
Enhancement: Require only PHP5.4 and above

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
 
 matrix:
   include:
+    - php: 5.4
     - php: 5.5
     - php: 5.6
       env: REPORT_COVERAGE=true

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": ">=5.5",
+        "php": ">=5.4",
         "container-interop/container-interop": "^1.1",
         "league/event": "^2.1.2"
     },

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "codeclimate/php-test-reporter": "0.2.0",
         "fabpot/php-cs-fixer": "2.0.*@dev",
         "phpunit/phpunit": "^4.8.7",
-        "refinery29/php-cs-fixer-config": "0.1.4"
+        "refinery29/php-cs-fixer-config": "0.1.5"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "bf28e33a2bc8f45817efe493a8fbf8f9",
+    "hash": "eb54dd08b86ecc5ebabfbb1ca99dfd3d",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -868,21 +868,21 @@
         },
         {
             "name": "refinery29/php-cs-fixer-config",
-            "version": "0.1.4",
+            "version": "0.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/refinery29/php-cs-fixer-config.git",
-                "reference": "049e5a80c18473d5adf6a1232255bd9c0df30879"
+                "reference": "f90e5958991a568e9352119a66b7551b1177bdb0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/refinery29/php-cs-fixer-config/zipball/049e5a80c18473d5adf6a1232255bd9c0df30879",
-                "reference": "049e5a80c18473d5adf6a1232255bd9c0df30879",
+                "url": "https://api.github.com/repos/refinery29/php-cs-fixer-config/zipball/f90e5958991a568e9352119a66b7551b1177bdb0",
+                "reference": "f90e5958991a568e9352119a66b7551b1177bdb0",
                 "shasum": ""
             },
             "require": {
                 "fabpot/php-cs-fixer": "2.0.*@dev",
-                "php": ">=5.5"
+                "php": ">=5.4"
             },
             "require-dev": {
                 "codeclimate/php-test-reporter": "^0.1.2",
@@ -905,7 +905,7 @@
                 }
             ],
             "description": "Provides a configuration for fabpot/php-cs-fixer, used within Refinery29.",
-            "time": "2015-09-04 15:09:45"
+            "time": "2015-09-14 12:18:40"
         },
         {
             "name": "satooshi/php-coveralls",
@@ -1401,12 +1401,12 @@
             "version": "v2.7.4",
             "source": {
                 "type": "git",
-                "url": "git@github.com:symfony/Console.git",
+                "url": "https://github.com/symfony/Console.git",
                 "reference": "f1f7376766394f409b9b33a57a5675a52f8aad93"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Console/zipball/f1f7376766394f409b9b33a57a5675a52f8aad93",
+                "url": "https://api.github.com/repos/symfony/Console/zipball/9ff9032151186bd66ecee727d728f1319f52d1d8",
                 "reference": "f1f7376766394f409b9b33a57a5675a52f8aad93",
                 "shasum": ""
             },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "b3fee81095cfb28bfa871470951551f3",
+    "hash": "bf28e33a2bc8f45817efe493a8fbf8f9",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -1765,7 +1765,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.5"
+        "php": ">=5.4"
     },
     "platform-dev": []
 }

--- a/tests/LazyListenerTest.php
+++ b/tests/LazyListenerTest.php
@@ -20,12 +20,12 @@ class LazyListenerTest extends \PHPUnit_Framework_TestCase
 
         $listener = new LazyListener($alias, $container);
 
-        $this->assertInstanceOf(ListenerInterface::class, $listener);
+        $this->assertInstanceOf('League\Event\ListenerInterface', $listener);
     }
 
     public function testGetListenerWhenActualListenerNotManagedByContainer()
     {
-        $this->setExpectedException(BadMethodCallException::class);
+        $this->setExpectedException('BadMethodCallException');
 
         $alias = 'foo';
 
@@ -45,7 +45,7 @@ class LazyListenerTest extends \PHPUnit_Framework_TestCase
 
     public function testGetListenerWhenFetchingActualListenerImpossible()
     {
-        $this->setExpectedException(BadMethodCallException::class);
+        $this->setExpectedException('BadMethodCallException');
 
         $alias = 'foo';
 
@@ -65,7 +65,7 @@ class LazyListenerTest extends \PHPUnit_Framework_TestCase
 
     public function testGetListenerWhenActualListenerDoesNotImplementListenerInterface()
     {
-        $this->setExpectedException(BadMethodCallException::class);
+        $this->setExpectedException('BadMethodCallException');
 
         $alias = 'foo';
 
@@ -250,7 +250,7 @@ class LazyListenerTest extends \PHPUnit_Framework_TestCase
      */
     private function getContainerMock()
     {
-        return $this->getMockBuilder(ContainerInterface::class)->getMock();
+        return $this->getMockBuilder('Interop\Container\ContainerInterface')->getMock();
     }
 
     /**
@@ -258,7 +258,7 @@ class LazyListenerTest extends \PHPUnit_Framework_TestCase
      */
     private function getEventMock()
     {
-        return $this->getMockBuilder(EventInterface::class)->getMock();
+        return $this->getMockBuilder('League\Event\EventInterface')->getMock();
     }
 
     /**
@@ -266,7 +266,7 @@ class LazyListenerTest extends \PHPUnit_Framework_TestCase
      */
     private function getLazyListenerMock()
     {
-        return $this->getMockBuilder(LazyListener::class)
+        return $this->getMockBuilder('Refinery29\Event\LazyListener')
             ->disableOriginalConstructor()
             ->getMock()
         ;
@@ -277,6 +277,6 @@ class LazyListenerTest extends \PHPUnit_Framework_TestCase
      */
     private function getListenerMock()
     {
-        return $this->getMockBuilder(ListenerInterface::class)->getMock();
+        return $this->getMockBuilder('League\Event\ListenerInterface')->getMock();
     }
 }


### PR DESCRIPTION
This PR

* [x] runs a build against PHP5.4
* [x] requires PHP5.4 and above in `composer.json`
* [x] removes usages of the `class` keyword
* [x] requires `refinery29/php-cs-fixer-config:0.1.5`