### PR TITLE
Fix: Disable xdebug when it is not needed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
     - php: 5.4
     - php: 5.5
     - php: 5.6
-      env: REPORT_COVERAGE=true
+      env: WITH_COVERAGE=true
     - php: 7
     - php: hhvm
 
@@ -22,6 +22,8 @@ cache:
     - $HOME/.php-cs-fixer
 
 before_install:
+  - if [[ "$TRAVIS_PULL_REQUEST" == "false" && "$TRAVIS_BRANCH" == "master" && "$WITH_COVERAGE" == "true" ]]; then COLLECT_COVERAGE=true; else COLLECT_COVERAGE=false; fi
+  - if [[ "$COLLECT_COVERAGE" == "false" && "$TRAVIS_PHP_VERSION" != "hhvm" ]]; then phpenv config-rm xdebug.ini; fi
   - composer self-update
   - composer validate
   - composer config github-oauth.github.com $GITHUB_TOKEN
@@ -30,15 +32,14 @@ install:
   - composer install --prefer-dist
 
 before_script:
-  - if [[ "$TRAVIS_PULL_REQUEST" == "false" && "$TRAVIS_BRANCH" == "master" ]]; then IS_MERGE_TO_MASTER=true; else IS_MERGE_TO_MASTER=false; fi
   - mkdir -p $HOME/.php-cs-fixer
 
 script:
-  - if [[ "$REPORT_COVERAGE" == "true" && "$IS_MERGE_TO_MASTER" == "true" ]]; then vendor/bin/phpunit --configuration phpunit.xml --coverage-clover=build/logs/clover.xml; else vendor/bin/phpunit --configuration phpunit.xml; fi
+  - if [[ "$COLLECT_COVERAGE" == "true" ]]; then vendor/bin/phpunit --configuration phpunit.xml --coverage-clover=build/logs/clover.xml; else vendor/bin/phpunit --configuration phpunit.xml; fi
   - vendor/bin/php-cs-fixer fix --config-file=.php_cs --verbose --diff --dry-run
 
 after_success:
-  - if [[ "$REPORT_COVERAGE" == "true" && "$IS_MERGE_TO_MASTER" == "true" ]]; then vendor/bin/test-reporter; fi
+  - if [[ "$COLLECT_COVERAGE" == "true" ]]; then vendor/bin/test-reporter; fi
 
 notifications:
   email: false


### PR DESCRIPTION
This PR

* [x] disables xdebug when we don't need it

:information_desk_person: We only need it for collecting coverage, and that only happens on one build, after merging into `master`.