### PR TITLE
Fix: Maintain order

### DIFF
--- a/src/LazyListener.php
+++ b/src/LazyListener.php
@@ -30,8 +30,8 @@ class LazyListener implements ListenerInterface
      */
     public function __construct($alias, ContainerInterface $container)
     {
-        $this->container = $container;
         $this->alias = $alias;
+        $this->container = $container;
     }
 
     /**


### PR DESCRIPTION
This PR

* [x] maintains the right order when assigning constructor arguments to instance properties