### PR TITLE
Fix: Add it target

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ $ make test
 
 to run all of the test suites.
 
-### Coding Standards
+## Coding Standards
 
 We are using [`fabpot/php-cs-fixer`](https://github.com/FriendsOfPHP/PHP-CS-Fixer) to enforce coding standards.
 
@@ -31,3 +31,13 @@ $ make cs
 ```
 
 to automatically fix coding standard violations.
+
+## Extra lazy?
+
+Run
+
+```
+$ make it
+```
+
+to run both coding standards check and tests!

--- a/Makefile
+++ b/Makefile
@@ -5,5 +5,7 @@ composer:
 cs: composer
 	vendor/bin/php-cs-fixer fix --config-file=.php_cs --verbose --diff
 
+it: cs test
+
 test: composer
 	vendor/bin/phpunit --configuration phpunit.xml --columns max


### PR DESCRIPTION
This PR

* [x] adds an `it` target, depending on `cs` and `test

::information_desk_person: Run

```
$ make it
```