### PR TITLE
Fix: Remove unused import

### DIFF
--- a/test/LazyListenerTest.php
+++ b/test/LazyListenerTest.php
@@ -2,7 +2,6 @@
 
 namespace Refinery29\Test\Event;
 
-use BadMethodCallException;
 use Interop\Container\ContainerInterface;
 use League\Event\EventInterface;
 use League\Event\ListenerInterface;


### PR DESCRIPTION
This PR

* [x] removes an unused import from a test

Related to #24.