### PR TITLE
Fix: Docblock

### DIFF
--- a/src/LazyListener.php
+++ b/src/LazyListener.php
@@ -2,6 +2,7 @@
 
 namespace Refinery29\Event;
 
+use BadMethodCallException;
 use Interop\Container\ContainerInterface;
 use Interop\Container\Exception\ContainerException;
 use League\Event\CallbackListener;
@@ -36,6 +37,8 @@ class LazyListener implements ListenerInterface
     }
 
     /**
+     * @throws BadMethodCallException
+     *
      * @return ListenerInterface
      */
     public function getListener()


### PR DESCRIPTION
This PR

* [x] adds a missing `@throws` to a docblock

Follows #27.