### PR TITLE
Fix: Update refinery29/php-cs-fixer-config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ before_script:
 
 script:
   - if [[ "$WITH_COVERAGE" == "true" && "$IS_MERGE_TO_MASTER" == "true" ]]; then vendor/bin/phpunit --configuration=phpunit.xml --coverage-clover=build/logs/clover.xml; else vendor/bin/phpunit --configuration=phpunit.xml; fi
-  - if [[ "$WITH_CS" == "true" ]]; then vendor/bin/php-cs-fixer fix --config-file=.php_cs --verbose --diff --dry-run; fi
+  - if [[ "$WITH_CS" == "true" ]]; then vendor/bin/php-cs-fixer fix --config=.php_cs --verbose --diff --dry-run; fi
 
 after_success:
   - if [[ "$WITH_COVERAGE" == "true" && "$IS_MERGE_TO_MASTER" == "true" ]]; then vendor/bin/test-reporter --coverage-report=build/logs/clover.xml; fi

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ composer:
 	composer install
 
 cs: composer
-	vendor/bin/php-cs-fixer fix --config-file=.php_cs --verbose --diff
+	vendor/bin/php-cs-fixer fix --config=.php_cs --verbose --diff
 
 it: cs test
 

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require-dev": {
         "codeclimate/php-test-reporter": "0.2.0",
         "phpunit/phpunit": "^4.8.7",
-        "refinery29/php-cs-fixer-config": "0.3.4"
+        "refinery29/php-cs-fixer-config": "0.4.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "e2e76a7881139c82e793aa354c2178f9",
-    "content-hash": "b443b23a916ec12214838dc69a31690e",
+    "hash": "8f9eefcc731c4d6fee2fdf51fc471ef1",
+    "content-hash": "edaa7f6b29ec9d02f9770701facd1829",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -204,24 +204,24 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
-                "reference": "2ac4bdb4cb989d7b32821265ef6dcdf9dcda06ba"
+                "reference": "518194b0e92dc75e791490b36b51cce39fe80bcf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/2ac4bdb4cb989d7b32821265ef6dcdf9dcda06ba",
-                "reference": "2ac4bdb4cb989d7b32821265ef6dcdf9dcda06ba",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/518194b0e92dc75e791490b36b51cce39fe80bcf",
+                "reference": "518194b0e92dc75e791490b36b51cce39fe80bcf",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
-                "php": ">=5.3.6",
-                "sebastian/diff": "~1.1",
-                "symfony/console": "~2.3|~3.0",
-                "symfony/event-dispatcher": "~2.1|~3.0",
-                "symfony/filesystem": "~2.1|~3.0",
-                "symfony/finder": "~2.1|~3.0",
-                "symfony/process": "~2.3|~3.0",
-                "symfony/stopwatch": "~2.5|~3.0"
+                "php": "^5.3.6 || ^7.0",
+                "sebastian/diff": "^1.1",
+                "symfony/console": "^2.3 || ^3.0",
+                "symfony/event-dispatcher": "^2.1 || ^3.0",
+                "symfony/filesystem": "^2.1 || ^3.0",
+                "symfony/finder": "^2.1 || ^3.0",
+                "symfony/process": "^2.3 || ^3.0",
+                "symfony/stopwatch": "^2.5 || ^3.0"
             },
             "require-dev": {
                 "satooshi/php-coveralls": "^1.0"
@@ -237,7 +237,7 @@
             },
             "autoload": {
                 "psr-4": {
-                    "Symfony\\CS\\": "src/"
+                    "PhpCsFixer\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -255,7 +255,7 @@
                 }
             ],
             "description": "A tool to automatically fix PHP code style",
-            "time": "2016-01-26 00:20:40"
+            "time": "2016-02-01 02:32:56"
         },
         {
             "name": "guzzle/guzzle",
@@ -869,20 +869,20 @@
         },
         {
             "name": "refinery29/php-cs-fixer-config",
-            "version": "0.3.4",
+            "version": "0.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/refinery29/php-cs-fixer-config.git",
-                "reference": "72146f611756d52b0ee9200a10c72cfc33a84c93"
+                "reference": "8c614d37a6e71e09762eec95b6a6c2eb0416c8e4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/refinery29/php-cs-fixer-config/zipball/72146f611756d52b0ee9200a10c72cfc33a84c93",
-                "reference": "72146f611756d52b0ee9200a10c72cfc33a84c93",
+                "url": "https://api.github.com/repos/refinery29/php-cs-fixer-config/zipball/8c614d37a6e71e09762eec95b6a6c2eb0416c8e4",
+                "reference": "8c614d37a6e71e09762eec95b6a6c2eb0416c8e4",
                 "shasum": ""
             },
             "require": {
-                "fabpot/php-cs-fixer": "dev-master#2ac4bdb",
+                "fabpot/php-cs-fixer": "dev-master#518194b",
                 "php": ">=5.5"
             },
             "require-dev": {
@@ -906,7 +906,7 @@
                 }
             ],
             "description": "Provides a configuration for fabpot/php-cs-fixer, used within Refinery29.",
-            "time": "2016-01-26 21:29:54"
+            "time": "2016-02-01 10:51:34"
         },
         {
             "name": "satooshi/php-coveralls",

--- a/src/LazyListener.php
+++ b/src/LazyListener.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Event;
 
 use BadMethodCallException;

--- a/test/ContainerException.php
+++ b/test/ContainerException.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Event\Test;
 
 use Interop\Container\Exception;

--- a/test/LazyListenerTest.php
+++ b/test/LazyListenerTest.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Event\Test;
 
 use Interop\Container\ContainerInterface;

--- a/test/NotFoundException.php
+++ b/test/NotFoundException.php
@@ -6,7 +6,6 @@
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  */
-
 namespace Refinery29\Event\Test;
 
 use Interop\Container\Exception;


### PR DESCRIPTION
This PR

* [x] updates `refinery29/php-cs-fixer-config`
* [x] adjusts `Makefile` and `.travis.yml`
* [x] runs `make cs`

Follows https://github.com/refinery29/php-cs-fixer-config/releases/tag/0.4.0.