### PR TITLE
Fix: Make it the first target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
+it: cs test
+
 composer:
 	composer validate
 	composer install
 
 cs: composer
 	vendor/bin/php-cs-fixer fix --config=.php_cs --verbose --diff
-
-it: cs test
 
 test: composer
 	vendor/bin/phpunit --configuration phpunit.xml --columns max


### PR DESCRIPTION
This PR

* [x] makes `it` the first target in `Makefile`

🙎 Otherwise, running

```
$ make
```

doesn't have the desired effect.
