### PR TITLE
Fix: Limit range of accepted PHP versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "sort-packages": true
     },
     "require": {
-        "php": ">=5.4",
+        "php": "^5.4 || ^7.0",
         "container-interop/container-interop": "^1.1",
         "league/event": "^2.1.2"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "892220c7dadc8a696c1975fafaf1828a",
-    "content-hash": "55906ddd408dd829d264328704fefcb1",
+    "hash": "6befb76a6fcfe0d3ae4db1313e86c001",
+    "content-hash": "0e1a19386c26a84a10897a7c16aad89e",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -1888,7 +1888,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.4"
+        "php": "^5.4 || ^7.0"
     },
     "platform-dev": []
 }


### PR DESCRIPTION
This PR

* [x] limits the range of accepted PHP versions

💁‍♂️ Can't tell yet whether this is going to be compatible with PHP 9000.
