### PR TITLE
Fix: Drop HHVM from build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ matrix:
       env: WITH_CS=true
     - php: 7.1
       env: WITH_COVERAGE=true
-    - php: hhvm
 
 cache:
   directories:


### PR DESCRIPTION
This PR

* [x] drops HHVM from the build matrix
