### PR TITLE
Fix: Configure preferred installation source in composer.json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_install:
   - composer config github-oauth.github.com $GITHUB_TOKEN
 
 install:
-  - composer install --prefer-dist
+  - composer install
 
 before_script:
   - mkdir -p "$HOME/.php-cs-fixer"

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "config": {
+        "preferred-install": "dist",
         "sort-packages": true
     },
     "require": {


### PR DESCRIPTION
This PR

* [x] configures the preferred installation source via `composer.json`

💁‍♂️ For reference, see https://getcomposer.org/doc/06-config.md#preferred-install.